### PR TITLE
Fixed Glow to work with newer versions of 1.8.9 Optifine

### DIFF
--- a/src/main/java/codes/biscuit/lobbyglow/mixins/MixinRenderGlobal.java
+++ b/src/main/java/codes/biscuit/lobbyglow/mixins/MixinRenderGlobal.java
@@ -61,7 +61,7 @@ public abstract class MixinRenderGlobal {
 //    }
 
     @Inject(method = "renderEntities", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/profiler/Profiler;endStartSection(Ljava/lang/String;)V", shift = At.Shift.BEFORE, ordinal = 2, args = {"ldc=entities"}), locals = LocalCapture.CAPTURE_FAILSOFT) // Optifine version
-    private void renderEntities(Entity renderViewEntity, ICamera camera, float partialTicks, CallbackInfo ci, int pass, double d0, double d1, double d2, Entity entity, double d3, double d4, double d5, List<Entity> list, boolean bool0, boolean bool1, int i1) {
+    private void renderEntities(Entity renderViewEntity, ICamera camera, float partialTicks, CallbackInfo ci, int pass, double d0, double d1, double d2, Entity entity, double d3, double d4, double d5, List<Entity> list, boolean bool0, boolean bool1) {
         displayOutlines(list, d0, d1, d2, camera, partialTicks);
     }
 


### PR DESCRIPTION
Allows This mod to work with the newest versions of Optifine as Optifine no longer uses one of the declared variables causing the mod to not work if combined with Optifine